### PR TITLE
Fix unbound variable errors in init.sh, console, and http modules

### DIFF
--- a/lib/init.sh
+++ b/lib/init.sh
@@ -7,7 +7,7 @@
 # DEBUG WRAPPER
 #---------------------------------------
 __debug() {
-  [[ "${BASH__VERBOSE}" == "debug" ]] && printf "DEBUG: %s\n" "$*" >&2
+  [[ "${BASH__VERBOSE:-}" == "debug" ]] && printf "DEBUG: %s\n" "$*" >&2
 }
 
 #---------------------------------------
@@ -21,7 +21,7 @@ fi
 #---------------------------------------
 # Docker Timeout Setup
 #---------------------------------------
-if [[ "${BASH_LIB_DOCKER}" == "true" ]]; then
+if [[ "${BASH_LIB_DOCKER:-}" == "true" ]]; then
   TIMEOUT_SECONDS=30
   __debug "Docker detected. Timeout set to ${TIMEOUT_SECONDS}s"
 fi
@@ -195,7 +195,7 @@ main_init() {
 # Initialize the result variable
 init_result=0
 
-if [[ "${BASH_LIB_DOCKER}" == "true" ]]; then
+if [[ "${BASH_LIB_DOCKER:-}" == "true" ]]; then
     # Simplified Docker initialization without timeout
     main_init
     init_result=$?

--- a/lib/modules/system/console.mod.sh
+++ b/lib/modules/system/console.mod.sh
@@ -247,7 +247,7 @@ console.set_verbosity() {
     else
         # Fallback for older bash versions
         local var_name="__CONSOLE__LEVELS_${level}"
-        if [[ -n "${!var_name}" ]]; then
+        if [[ -n "${!var_name:-}" ]]; then
             export BASH__VERBOSE="$level"
             # Only log if debug level is allowed
             if __console__should_log "debug"; then


### PR DESCRIPTION
- Guard all variable expansions with default values (set -u safe)
- Fix indirect variable expansion in console.mod.sh
- No-op re-imports are safe; real issue was unguarded variables
- Now works in Docker and strict shells