### PR TITLE
ci: run example scripts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
       run: |
         bash scripts/install.sh help
 
+  - name: Run example scripts
+    run: |
+      find lib/docs/examples -name "*.sh" | while read -r script; do
+        echo "Running $script"
+        bash -euo pipefail "$script"
+      done
+
   build:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request adds a new step in the CI workflow to run all example scripts located under `lib/docs/examples` with `bash -euo pipefail`. This will help ensure that example scripts remain functional and catch integration issues that unit tests might miss.

Closes #23.